### PR TITLE
Fixing the config on SRL for 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ clab-*
 site/
 tmp
 .*clab.y*ml
+*bak

--- a/configs/gnmic.yml
+++ b/configs/gnmic.yml
@@ -1,5 +1,5 @@
 username: admin
-password: admin
+password: NokiaSrl1!
 port: 57400
 timeout: 10s
 skip-verify: true

--- a/configs/leaf1.cfg
+++ b/configs/leaf1.cfg
@@ -43,7 +43,7 @@ set / network-instance default interface system0.0
 set / routing-policy
 set / routing-policy policy all
 set / routing-policy policy all default-action
-set / routing-policy policy all default-action accept
+set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols
@@ -51,21 +51,20 @@ set / network-instance default protocols bgp
 set / network-instance default protocols bgp autonomous-system 101
 set / network-instance default protocols bgp router-id 10.0.0.1
 set / network-instance default protocols bgp group eBGP-underlay
-set / network-instance default protocols bgp group eBGP-underlay export-policy all
-set / network-instance default protocols bgp group eBGP-underlay import-policy all
+set / network-instance default protocols bgp group eBGP-underlay export-policy [all]
+set / network-instance default protocols bgp group eBGP-underlay import-policy [all]
 set / network-instance default protocols bgp group eBGP-underlay peer-as 201
 set / network-instance default protocols bgp group eBGP-underlay timers
 set / network-instance default protocols bgp group eBGP-underlay timers connect-retry 1
 set / network-instance default protocols bgp group eBGP-underlay timers hold-time 9
 set / network-instance default protocols bgp group eBGP-underlay timers keepalive-interval 3
 set / network-instance default protocols bgp group eBGP-underlay timers minimum-advertisement-interval 1
-set / network-instance default protocols bgp ipv4-unicast
-set / network-instance default protocols bgp ipv4-unicast admin-state enable
-set / network-instance default protocols bgp ipv4-unicast multipath
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-1 4
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-2 4
-set / network-instance default protocols bgp evpn
-set / network-instance default protocols bgp evpn rapid-update true
+set / network-instance default protocols bgp afi-safi ipv4-unicast
+set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath maximum-paths 4
+set / network-instance default protocols bgp afi-safi evpn
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp neighbor 192.168.11.2
 set / network-instance default protocols bgp neighbor 192.168.11.2 peer-group eBGP-underlay
 set / network-instance default protocols bgp neighbor 192.168.12.2
@@ -74,14 +73,14 @@ set / network-instance default protocols bgp neighbor 192.168.12.2 peer-group eB
 # iBGP neighbor config
 # each leaf peers with two spines
 set / network-instance default protocols bgp group iBGP-overlay
-set / network-instance default protocols bgp group iBGP-overlay export-policy all
-set / network-instance default protocols bgp group iBGP-overlay import-policy all
+set / network-instance default protocols bgp group iBGP-overlay export-policy [all]
+set / network-instance default protocols bgp group iBGP-overlay import-policy [all]
 set / network-instance default protocols bgp group iBGP-overlay peer-as 100
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay evpn
-set / network-instance default protocols bgp group iBGP-overlay evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay local-as 100
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group iBGP-overlay local-as as-number 100
 set / network-instance default protocols bgp group iBGP-overlay timers
 set / network-instance default protocols bgp group iBGP-overlay timers connect-retry 1
 set / network-instance default protocols bgp group iBGP-overlay timers hold-time 9

--- a/configs/leaf1.cfg
+++ b/configs/leaf1.cfg
@@ -1,12 +1,12 @@
 # uplink interfaces
 set / interface ethernet-1/49
 set / interface ethernet-1/49 subinterface 0
-set / interface ethernet-1/49 subinterface 0 ipv4
+set / interface ethernet-1/49 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/49 subinterface 0 ipv4 address 192.168.11.1/30
 set / interface ethernet-1/49 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/50
 set / interface ethernet-1/50 subinterface 0
-set / interface ethernet-1/50 subinterface 0 ipv4
+set / interface ethernet-1/50 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/50 subinterface 0 ipv4 address 192.168.12.1/30
 set / interface ethernet-1/50 subinterface 0 ip-mtu 9000
 
@@ -30,7 +30,7 @@ set / interface lag1 lag lacp system-id-mac 00:00:00:00:00:01
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
-set / interface system0 subinterface 0 ipv4
+set / interface system0 subinterface 0 ipv4 admin-state enable
 set / interface system0 subinterface 0 ipv4 address 10.0.0.1/32
 
 # associating interfaces with net-ins default

--- a/configs/leaf2.cfg
+++ b/configs/leaf2.cfg
@@ -1,12 +1,12 @@
 # configuration of the physical interface and its subinterface
 set / interface ethernet-1/49
 set / interface ethernet-1/49 subinterface 0
-set / interface ethernet-1/49 subinterface 0 ipv4
+set / interface ethernet-1/49 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/49 subinterface 0 ipv4 address 192.168.21.1/30
 set / interface ethernet-1/49 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/50
 set / interface ethernet-1/50 subinterface 0
-set / interface ethernet-1/50 subinterface 0 ipv4
+set / interface ethernet-1/50 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/50 subinterface 0 ipv4 address 192.168.22.1/30
 set / interface ethernet-1/50 subinterface 0 ip-mtu 9000
 
@@ -30,7 +30,7 @@ set / interface lag1 lag lacp system-id-mac 00:00:00:00:00:01
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
-set / interface system0 subinterface 0 ipv4
+set / interface system0 subinterface 0 ipv4 admin-state enable
 set / interface system0 subinterface 0 ipv4 address 10.0.0.2/32
 
 # associating interfaces with net-ins default

--- a/configs/leaf2.cfg
+++ b/configs/leaf2.cfg
@@ -43,7 +43,7 @@ set / network-instance default interface system0.0
 set / routing-policy
 set / routing-policy policy all
 set / routing-policy policy all default-action
-set / routing-policy policy all default-action accept
+set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols
@@ -51,21 +51,20 @@ set / network-instance default protocols bgp
 set / network-instance default protocols bgp autonomous-system 102
 set / network-instance default protocols bgp router-id 10.0.0.2
 set / network-instance default protocols bgp group eBGP-underlay
-set / network-instance default protocols bgp group eBGP-underlay export-policy all
-set / network-instance default protocols bgp group eBGP-underlay import-policy all
+set / network-instance default protocols bgp group eBGP-underlay export-policy [all]
+set / network-instance default protocols bgp group eBGP-underlay import-policy [all]
 set / network-instance default protocols bgp group eBGP-underlay peer-as 201
 set / network-instance default protocols bgp group eBGP-underlay timers
 set / network-instance default protocols bgp group eBGP-underlay timers connect-retry 1
 set / network-instance default protocols bgp group eBGP-underlay timers hold-time 9
 set / network-instance default protocols bgp group eBGP-underlay timers keepalive-interval 3
 set / network-instance default protocols bgp group eBGP-underlay timers minimum-advertisement-interval 1
-set / network-instance default protocols bgp ipv4-unicast
-set / network-instance default protocols bgp ipv4-unicast admin-state enable
-set / network-instance default protocols bgp ipv4-unicast multipath
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-1 4
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-2 4
-set / network-instance default protocols bgp evpn
-set / network-instance default protocols bgp evpn rapid-update true
+set / network-instance default protocols bgp afi-safi ipv4-unicast
+set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath maximum-paths 4
+set / network-instance default protocols bgp afi-safi evpn
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp neighbor 192.168.21.2
 set / network-instance default protocols bgp neighbor 192.168.21.2 peer-group eBGP-underlay
 set / network-instance default protocols bgp neighbor 192.168.22.2
@@ -73,14 +72,14 @@ set / network-instance default protocols bgp neighbor 192.168.22.2 peer-group eB
 
 # iBGP neighbor config
 set / network-instance default protocols bgp group iBGP-overlay
-set / network-instance default protocols bgp group iBGP-overlay export-policy all
-set / network-instance default protocols bgp group iBGP-overlay import-policy all
+set / network-instance default protocols bgp group iBGP-overlay export-policy [all]
+set / network-instance default protocols bgp group iBGP-overlay import-policy [all]
 set / network-instance default protocols bgp group iBGP-overlay peer-as 100
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay evpn
-set / network-instance default protocols bgp group iBGP-overlay evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay local-as 100
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group iBGP-overlay local-as as-number 100
 set / network-instance default protocols bgp group iBGP-overlay timers
 set / network-instance default protocols bgp group iBGP-overlay timers connect-retry 1
 set / network-instance default protocols bgp group iBGP-overlay timers hold-time 9

--- a/configs/leaf3.cfg
+++ b/configs/leaf3.cfg
@@ -43,7 +43,7 @@ set / network-instance default interface system0.0
 set / routing-policy
 set / routing-policy policy all
 set / routing-policy policy all default-action
-set / routing-policy policy all default-action accept
+set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols
@@ -51,16 +51,16 @@ set / network-instance default protocols bgp
 set / network-instance default protocols bgp autonomous-system 103
 set / network-instance default protocols bgp router-id 10.0.0.3
 set / network-instance default protocols bgp group eBGP-underlay
-set / network-instance default protocols bgp group eBGP-underlay export-policy all
-set / network-instance default protocols bgp group eBGP-underlay import-policy all
+set / network-instance default protocols bgp group eBGP-underlay export-policy [all]
+set / network-instance default protocols bgp group eBGP-underlay import-policy [all]
 set / network-instance default protocols bgp group eBGP-underlay peer-as 201
 set / network-instance default protocols bgp group eBGP-underlay timers
 set / network-instance default protocols bgp group eBGP-underlay timers connect-retry 1
 set / network-instance default protocols bgp group eBGP-underlay timers hold-time 9
 set / network-instance default protocols bgp group eBGP-underlay timers keepalive-interval 3
 set / network-instance default protocols bgp group eBGP-underlay timers minimum-advertisement-interval 1
-set / network-instance default protocols bgp ipv4-unicast
-set / network-instance default protocols bgp ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast
+set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
 set / network-instance default protocols bgp neighbor 192.168.31.2
 set / network-instance default protocols bgp neighbor 192.168.31.2 peer-group eBGP-underlay
 set / network-instance default protocols bgp neighbor 192.168.32.2
@@ -68,19 +68,18 @@ set / network-instance default protocols bgp neighbor 192.168.32.2 peer-group eB
 
 # iBGP neighbor config
 set / network-instance default protocols bgp group iBGP-overlay
-set / network-instance default protocols bgp group iBGP-overlay export-policy all
-set / network-instance default protocols bgp group iBGP-overlay import-policy all
+set / network-instance default protocols bgp group iBGP-overlay export-policy [all]
+set / network-instance default protocols bgp group iBGP-overlay import-policy [all]
 set / network-instance default protocols bgp group iBGP-overlay peer-as 100
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast admin-state disable
-set / network-instance default protocols bgp ipv4-unicast multipath
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-1 4
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-2 4
-set / network-instance default protocols bgp evpn
-set / network-instance default protocols bgp evpn rapid-update true
-set / network-instance default protocols bgp group iBGP-overlay evpn
-set / network-instance default protocols bgp group iBGP-overlay evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay local-as 100
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath maximum-paths 4
+set / network-instance default protocols bgp afi-safi evpn
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group iBGP-overlay local-as as-number 100
 set / network-instance default protocols bgp group iBGP-overlay timers
 set / network-instance default protocols bgp group iBGP-overlay timers connect-retry 1
 set / network-instance default protocols bgp group iBGP-overlay timers hold-time 9

--- a/configs/leaf3.cfg
+++ b/configs/leaf3.cfg
@@ -1,12 +1,12 @@
 # configuration of the physical interface and its subinterface
 set / interface ethernet-1/49
 set / interface ethernet-1/49 subinterface 0
-set / interface ethernet-1/49 subinterface 0 ipv4
+set / interface ethernet-1/49 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/49 subinterface 0 ipv4 address 192.168.31.1/30
 set / interface ethernet-1/49 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/50
 set / interface ethernet-1/50 subinterface 0
-set / interface ethernet-1/50 subinterface 0 ipv4
+set / interface ethernet-1/50 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/50 subinterface 0 ipv4 address 192.168.32.1/30
 set / interface ethernet-1/50 subinterface 0 ip-mtu 9000
 
@@ -30,7 +30,7 @@ set / interface lag1 lag lacp system-id-mac 00:00:00:00:00:01
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
-set / interface system0 subinterface 0 ipv4
+set / interface system0 subinterface 0 ipv4 admin-state enable
 set / interface system0 subinterface 0 ipv4 address 10.0.0.3/32
 
 # associating interfaces with net-ins default

--- a/configs/leaf4.cfg
+++ b/configs/leaf4.cfg
@@ -43,7 +43,7 @@ set / network-instance default interface system0.0
 set / routing-policy
 set / routing-policy policy all
 set / routing-policy policy all default-action
-set / routing-policy policy all default-action accept
+set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols
@@ -51,16 +51,16 @@ set / network-instance default protocols bgp
 set / network-instance default protocols bgp autonomous-system 104
 set / network-instance default protocols bgp router-id 10.0.0.4
 set / network-instance default protocols bgp group eBGP-underlay
-set / network-instance default protocols bgp group eBGP-underlay export-policy all
-set / network-instance default protocols bgp group eBGP-underlay import-policy all
+set / network-instance default protocols bgp group eBGP-underlay export-policy [all]
+set / network-instance default protocols bgp group eBGP-underlay import-policy [all]
 set / network-instance default protocols bgp group eBGP-underlay peer-as 201
 set / network-instance default protocols bgp group eBGP-underlay timers
 set / network-instance default protocols bgp group eBGP-underlay timers connect-retry 1
 set / network-instance default protocols bgp group eBGP-underlay timers hold-time 9
 set / network-instance default protocols bgp group eBGP-underlay timers keepalive-interval 3
 set / network-instance default protocols bgp group eBGP-underlay timers minimum-advertisement-interval 1
-set / network-instance default protocols bgp ipv4-unicast
-set / network-instance default protocols bgp ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast
+set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
 set / network-instance default protocols bgp neighbor 192.168.41.2
 set / network-instance default protocols bgp neighbor 192.168.41.2 peer-group eBGP-underlay
 set / network-instance default protocols bgp neighbor 192.168.42.2
@@ -68,19 +68,19 @@ set / network-instance default protocols bgp neighbor 192.168.42.2 peer-group eB
 
 # iBGP neighbor config
 set / network-instance default protocols bgp group iBGP-overlay
-set / network-instance default protocols bgp group iBGP-overlay export-policy all
-set / network-instance default protocols bgp group iBGP-overlay import-policy all
+set / network-instance default protocols bgp group iBGP-overlay export-policy [all]
+set / network-instance default protocols bgp group iBGP-overlay import-policy [all]
 set / network-instance default protocols bgp group iBGP-overlay peer-as 100
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast admin-state disable
-set / network-instance default protocols bgp ipv4-unicast multipath
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-1 4
-set / network-instance default protocols bgp ipv4-unicast multipath max-paths-level-2 4
-set / network-instance default protocols bgp evpn
-set / network-instance default protocols bgp evpn rapid-update true
-set / network-instance default protocols bgp group iBGP-overlay evpn
-set / network-instance default protocols bgp group iBGP-overlay evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay local-as 100
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath maximum-paths 4
+set / network-instance default protocols bgp afi-safi evpn
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group iBGP-overlay local-as as-number 100
 set / network-instance default protocols bgp group iBGP-overlay timers
 set / network-instance default protocols bgp group iBGP-overlay timers connect-retry 1
 set / network-instance default protocols bgp group iBGP-overlay timers hold-time 9

--- a/configs/leaf4.cfg
+++ b/configs/leaf4.cfg
@@ -1,12 +1,12 @@
 # configuration of the physical interfaces
 set / interface ethernet-1/49
 set / interface ethernet-1/49 subinterface 0
-set / interface ethernet-1/49 subinterface 0 ipv4
+set / interface ethernet-1/49 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/49 subinterface 0 ipv4 address 192.168.41.1/30
 set / interface ethernet-1/49 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/50
 set / interface ethernet-1/50 subinterface 0
-set / interface ethernet-1/50 subinterface 0 ipv4
+set / interface ethernet-1/50 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/50 subinterface 0 ipv4 address 192.168.42.1/30
 set / interface ethernet-1/50 subinterface 0 ip-mtu 9000
 
@@ -30,7 +30,7 @@ set / interface lag1 lag lacp system-id-mac 00:00:00:00:00:01
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
-set / interface system0 subinterface 0 ipv4
+set / interface system0 subinterface 0 ipv4 admin-state enable
 set / interface system0 subinterface 0 ipv4 address 10.0.0.4/32
 
 # associating interfaces with net-ins default

--- a/configs/spine1.cfg
+++ b/configs/spine1.cfg
@@ -39,7 +39,7 @@ set / network-instance default interface system0.0
 set / routing-policy
 set / routing-policy policy all
 set / routing-policy policy all default-action
-set / routing-policy policy all default-action accept
+set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols
@@ -47,17 +47,17 @@ set / network-instance default protocols bgp
 set / network-instance default protocols bgp autonomous-system 201
 set / network-instance default protocols bgp router-id 10.0.1.1
 set / network-instance default protocols bgp group eBGP-underlay
-set / network-instance default protocols bgp group eBGP-underlay export-policy all
-set / network-instance default protocols bgp group eBGP-underlay import-policy all
+set / network-instance default protocols bgp group eBGP-underlay export-policy [all]
+set / network-instance default protocols bgp group eBGP-underlay import-policy [all]
 set / network-instance default protocols bgp group eBGP-underlay timers
 set / network-instance default protocols bgp group eBGP-underlay timers connect-retry 1
 set / network-instance default protocols bgp group eBGP-underlay timers hold-time 9
 set / network-instance default protocols bgp group eBGP-underlay timers keepalive-interval 3
 set / network-instance default protocols bgp group eBGP-underlay timers minimum-advertisement-interval 1
-set / network-instance default protocols bgp ipv4-unicast
-set / network-instance default protocols bgp ipv4-unicast admin-state enable
-set / network-instance default protocols bgp evpn
-set / network-instance default protocols bgp evpn rapid-update true
+set / network-instance default protocols bgp afi-safi ipv4-unicast
+set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi evpn
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp neighbor 192.168.11.1
 set / network-instance default protocols bgp neighbor 192.168.11.1 peer-as 101
 set / network-instance default protocols bgp neighbor 192.168.11.1 peer-group eBGP-underlay
@@ -73,14 +73,14 @@ set / network-instance default protocols bgp neighbor 192.168.41.1 peer-group eB
 
 # iBGP RR configuration
 set / network-instance default protocols bgp group iBGP-overlay
-set / network-instance default protocols bgp group iBGP-overlay export-policy all
-set / network-instance default protocols bgp group iBGP-overlay import-policy all
+set / network-instance default protocols bgp group iBGP-overlay export-policy [all]
+set / network-instance default protocols bgp group iBGP-overlay import-policy [all]
 set / network-instance default protocols bgp group iBGP-overlay peer-as 100
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay evpn
-set / network-instance default protocols bgp group iBGP-overlay evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay local-as 100
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group iBGP-overlay local-as as-number 100
 set / network-instance default protocols bgp group iBGP-overlay timers
 set / network-instance default protocols bgp group iBGP-overlay timers connect-retry 1
 set / network-instance default protocols bgp group iBGP-overlay timers hold-time 9

--- a/configs/spine1.cfg
+++ b/configs/spine1.cfg
@@ -1,22 +1,22 @@
 # configuration of the physical interface and its subinterface
 set / interface ethernet-1/1
 set / interface ethernet-1/1 subinterface 0
-set / interface ethernet-1/1 subinterface 0 ipv4
+set / interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.11.2/30
 set / interface ethernet-1/1 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/2
 set / interface ethernet-1/2 subinterface 0
-set / interface ethernet-1/2 subinterface 0 ipv4
+set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/2 subinterface 0 ipv4 address 192.168.21.2/30
 set / interface ethernet-1/2 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/3
 set / interface ethernet-1/3 subinterface 0
-set / interface ethernet-1/3 subinterface 0 ipv4
+set / interface ethernet-1/3 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/3 subinterface 0 ipv4 address 192.168.31.2/30
 set / interface ethernet-1/3 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/4
 set / interface ethernet-1/4 subinterface 0
-set / interface ethernet-1/4 subinterface 0 ipv4
+set / interface ethernet-1/4 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/4 subinterface 0 ipv4 address 192.168.41.2/30
 set / interface ethernet-1/4 subinterface 0 ip-mtu 9000
 
@@ -24,7 +24,7 @@ set / interface ethernet-1/4 subinterface 0 ip-mtu 9000
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
-set / interface system0 subinterface 0 ipv4
+set / interface system0 subinterface 0 ipv4 admin-state enable
 set / interface system0 subinterface 0 ipv4 address 10.0.1.1/32
 
 # associating interfaces with net-ins default

--- a/configs/spine2.cfg
+++ b/configs/spine2.cfg
@@ -1,22 +1,22 @@
 # configuration of the physical interface and its subinterface
 set / interface ethernet-1/1
 set / interface ethernet-1/1 subinterface 0
-set / interface ethernet-1/1 subinterface 0 ipv4
+set / interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.12.2/30
 set / interface ethernet-1/1 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/2
 set / interface ethernet-1/2 subinterface 0
-set / interface ethernet-1/2 subinterface 0 ipv4
+set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/2 subinterface 0 ipv4 address 192.168.22.2/30
 set / interface ethernet-1/2 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/3
 set / interface ethernet-1/3 subinterface 0
-set / interface ethernet-1/3 subinterface 0 ipv4
+set / interface ethernet-1/3 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/3 subinterface 0 ipv4 address 192.168.32.2/30
 set / interface ethernet-1/3 subinterface 0 ip-mtu 9000
 set / interface ethernet-1/4
 set / interface ethernet-1/4 subinterface 0
-set / interface ethernet-1/4 subinterface 0 ipv4
+set / interface ethernet-1/4 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/4 subinterface 0 ipv4 address 192.168.42.2/30
 set / interface ethernet-1/4 subinterface 0 ip-mtu 9000
 
@@ -24,7 +24,7 @@ set / interface ethernet-1/4 subinterface 0 ip-mtu 9000
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
-set / interface system0 subinterface 0 ipv4
+set / interface system0 subinterface 0 ipv4 admin-state enable
 set / interface system0 subinterface 0 ipv4 address 10.0.1.2/32
 
 # associating interfaces with net-ins default

--- a/configs/spine2.cfg
+++ b/configs/spine2.cfg
@@ -39,7 +39,7 @@ set / network-instance default interface system0.0
 set / routing-policy
 set / routing-policy policy all
 set / routing-policy policy all default-action
-set / routing-policy policy all default-action accept
+set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols
@@ -47,17 +47,17 @@ set / network-instance default protocols bgp
 set / network-instance default protocols bgp autonomous-system 201
 set / network-instance default protocols bgp router-id 10.0.1.2
 set / network-instance default protocols bgp group eBGP-underlay
-set / network-instance default protocols bgp group eBGP-underlay export-policy all
-set / network-instance default protocols bgp group eBGP-underlay import-policy all
+set / network-instance default protocols bgp group eBGP-underlay export-policy [all]
+set / network-instance default protocols bgp group eBGP-underlay import-policy [all]
 set / network-instance default protocols bgp group eBGP-underlay timers
 set / network-instance default protocols bgp group eBGP-underlay timers connect-retry 1
 set / network-instance default protocols bgp group eBGP-underlay timers hold-time 9
 set / network-instance default protocols bgp group eBGP-underlay timers keepalive-interval 3
 set / network-instance default protocols bgp group eBGP-underlay timers minimum-advertisement-interval 1
-set / network-instance default protocols bgp ipv4-unicast
-set / network-instance default protocols bgp ipv4-unicast admin-state enable
-set / network-instance default protocols bgp evpn
-set / network-instance default protocols bgp evpn rapid-update true
+set / network-instance default protocols bgp afi-safi ipv4-unicast
+set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi evpn
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp neighbor 192.168.12.1
 set / network-instance default protocols bgp neighbor 192.168.12.1 peer-as 101
 set / network-instance default protocols bgp neighbor 192.168.12.1 peer-group eBGP-underlay
@@ -73,14 +73,14 @@ set / network-instance default protocols bgp neighbor 192.168.42.1 peer-group eB
 
 # iBGP RR configuration
 set / network-instance default protocols bgp group iBGP-overlay
-set / network-instance default protocols bgp group iBGP-overlay export-policy all
-set / network-instance default protocols bgp group iBGP-overlay import-policy all
+set / network-instance default protocols bgp group iBGP-overlay export-policy [all]
+set / network-instance default protocols bgp group iBGP-overlay import-policy [all]
 set / network-instance default protocols bgp group iBGP-overlay peer-as 100
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast
-set / network-instance default protocols bgp group iBGP-overlay ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay evpn
-set / network-instance default protocols bgp group iBGP-overlay evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay local-as 100
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast
+set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn
+set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group iBGP-overlay local-as as-number 100
 set / network-instance default protocols bgp group iBGP-overlay timers
 set / network-instance default protocols bgp group iBGP-overlay timers connect-retry 1
 set / network-instance default protocols bgp group iBGP-overlay timers hold-time 9

--- a/opergroup.clab.yml
+++ b/opergroup.clab.yml
@@ -7,7 +7,7 @@ topology:
     kind: nokia_srlinux
   kinds:
     nokia_srlinux:
-      image: ghcr.io/nokia/srlinux:22.3.2
+      image: ghcr.io/nokia/srlinux:24.10.1
   nodes:
     ### FABRIC ###
     leaf1:

--- a/opergroup.clab.yml
+++ b/opergroup.clab.yml
@@ -1,4 +1,4 @@
-# topology documentation: http://learn.srlinux.dev/tutorials/programmability/event-handler/oper-group/
+# topology documentation: https://learn.srlinux.dev/tutorials/programmability/event-handler/oper-group/oper-group-cfg/
 name: opergroup
 prefix: ""
 
@@ -7,7 +7,7 @@ topology:
     kind: nokia_srlinux
   kinds:
     nokia_srlinux:
-      image: ghcr.io/nokia/srlinux:24.10.1
+      image: ghcr.io/nokia/srlinux:24.10.2
   nodes:
     ### FABRIC ###
     leaf1:
@@ -27,7 +27,7 @@ topology:
     ### CLIENTS ###
     client1:
       kind: linux
-      image: ghcr.io/hellt/network-multitool
+      image: ghcr.io/srl-labs/network-multitool
       binds:
         - configs/bond.sh:/tmp/bond.sh
       exec:
@@ -48,7 +48,7 @@ topology:
     ### TELEMETRY STACK ###
     gnmic:
       kind: linux
-      image: ghcr.io/karimra/gnmic:0.24.4
+      image: ghcr.io/openconfig/gnmic:0.40.0
       binds:
         - configs/gnmic.yml:/gnmic.yml:ro
       cmd: --config /gnmic.yml --log subscribe
@@ -73,7 +73,7 @@ topology:
         - 3000:3000
 
   links:
-    # client1/2 links towards leaves
+    # client1/2 links towards leafs
     - endpoints: ["client1:eth1", "leaf1:e1-1"]
     - endpoints: ["client1:eth2", "leaf2:e1-1"]
     - endpoints: ["client2:eth1", "leaf3:e1-1"]


### PR DESCRIPTION
1. Updated the default-action with policy-result knob
2. The import and export policy accepts arguments as list, updated.\
3. BGP: the Ipv4 and EVPN needs to be declared under afi-safi, updated
4. Mutipath has a feature which needs to be enabled, allow-multiple-as
5. Rapid Update under even has been added under additional even in 24.x
6. local-as takes argument under as-number, updated